### PR TITLE
fix paramerize bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1089,7 +1089,7 @@ dependencies = [
 
 [[package]]
 name = "shazam"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shazam"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2021"
 authors = ["Bradley Searle"]
 license = "MIT"

--- a/src/util/text.rs
+++ b/src/util/text.rs
@@ -4,11 +4,7 @@ use titlecase::titlecase;
 
 /// Convert a string to a parameterized string
 pub fn parameterize(source: String) -> String {
-    let stripped = source
-        .replace('-', " ")
-        .replace('_', " ")
-        .replace(':', " ")
-        .to_lowercase();
+    let stripped = source.replace(['-', '_', ':'], " ").to_lowercase();
 
     let split: Vec<&str> = stripped.split_ascii_whitespace().collect();
 

--- a/src/util/text.rs
+++ b/src/util/text.rs
@@ -4,7 +4,20 @@ use titlecase::titlecase;
 
 /// Convert a string to a parameterized string
 pub fn parameterize(source: String) -> String {
-    source.replace(' ', "-").to_lowercase()
+    let stripped = source
+        .replace('-', " ")
+        .replace('_', " ")
+        .replace(':', " ")
+        .to_lowercase();
+
+    let split: Vec<&str> = stripped.split_ascii_whitespace().collect();
+
+    split
+        .iter()
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join("-")
 }
 
 /// Convert a string to capital case.
@@ -35,6 +48,11 @@ mod tests {
             ("Test String".to_owned(), "test-string".to_owned()),
             ("TestString".to_owned(), "teststring".to_owned()),
             ("test string".to_owned(), "test-string".to_owned()),
+            ("test_string".to_owned(), "test-string".to_owned()),
+            ("test-string".to_owned(), "test-string".to_owned()),
+            ("test: string".to_owned(), "test-string".to_owned()),
+            ("test : - _ string".to_owned(), "test-string".to_owned()),
+            ("test :-_ string".to_owned(), "test-string".to_owned()),
         ];
         for t in test_cases {
             let result = parameterize(t.0);


### PR DESCRIPTION
the paramaterize helper does not correctly strip chars. 
 
Now strips
 - `-` Dashes
 - `_` Underscores
 - ` ` Blank Spaces

and returns and dash separated string